### PR TITLE
Add TypeScript interface to CopyIcon component

### DIFF
--- a/components/icons/CopyIcon.tsx
+++ b/components/icons/CopyIcon.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-export default function CopyIcon({ className = "w-4 h-4 flex-shrink-0" }) {
+interface CopyIconProps {
+  className?: string;
+}
+
+export default function CopyIcon({ className = "w-4 h-4 flex-shrink-0" }: CopyIconProps) {
   return (
     <svg
       className={className}


### PR DESCRIPTION
Adds proper TypeScript typing to the CopyIcon component for consistency with other icon components like GitHubIcon. This improves type safety and follows the established pattern in the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)