### PR TITLE
Add charmbracelet/crush to compatibility list. Closes #31

### DIFF
--- a/components/CompatibilitySection.tsx
+++ b/components/CompatibilitySection.tsx
@@ -112,7 +112,12 @@ export default function CompatibilitySection() {
       imageSrcLight: "/logos/devin-light.svg",
       imageSrcDark: "/logos/devin-dark.svg",
     },
-
+    {
+      name: "Crush",
+      url: "https://github.com/charmbracelet/crush",
+      from: "Charm",
+      imageSrc: "/logos/crush.svg"
+    },
   ];
   return (
     <Section

--- a/public/logos/crush.svg
+++ b/public/logos/crush.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   sodipodi:docname="crush-heart.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     showguides="true"
+     inkscape:zoom="16"
+     inkscape:cx="25.46875"
+     inkscape:cy="23.1875"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g112" /><defs
+     id="defs1" /><g
+     inkscape:label="Layer 1 copy"
+     inkscape:groupmode="layer"
+     id="g112"
+     style="display:inline"><path
+       id="path107"
+       style="display:inline;fill:#000000;fill-opacity:1;stroke-width:1.82587"
+       d="m 2.4058396,1.3966191 0.021417,0.7488913 H 1.5178687 V 2.9300627 H 0.53004592 V 6.9847741 H 1.2967677 V 8.3185144 H 2.102718 v 1.2303219 h 1.3515694 v 0.5028307 h 1.0484485 v 0.545618 h 0.9485966 v 0.706096 H 7.3092963 V 10.558056 H 8.2971192 V 10.051667 H 9.3669641 V 9.3847929 h 1.3515709 v -1.169697 h 0.805949 V 6.8849222 h 0.645471 V 2.8516079 H 11.26059 V 2.0634888 H 10.333391 V 1.3966191 H 7.5517941 V 2.1455104 H 6.9669455 V 2.8516079 H 5.8150791 V 2.1241125 H 5.2088369 V 1.3966191 Z M 7.6266833,5.1268108 H 8.0296558 V 6.3357355 H 7.6266833 Z m -2.8208242,0.00357 H 5.2088315 V 6.3393015 H 4.8058591 Z m 1.2731155,1.483515 H 6.9241518 V 6.956244 H 6.0789746 Z" /></g></svg>


### PR DESCRIPTION
Add charmbracelet/crush to compatible tools:

AGENTS.md are supported:

https://github.com/charmbracelet/crush/blob/d69dcc1ae314c55b0d3e93d06beb9320485fe1c3/internal/config/config.go#L39

https://github.com/charmbracelet/crush/discussions/842

Screeshot from local:

<img width="938" height="880" alt="image" src="https://github.com/user-attachments/assets/1b2a1a04-f623-46f9-b3dd-9e5779b66e02" />

Closes #31 
